### PR TITLE
Add a step to allow for "slowly" entering text

### DIFF
--- a/aloe_webdriver/__init__.py
+++ b/aloe_webdriver/__init__.py
@@ -10,6 +10,8 @@ from __future__ import absolute_import
 from builtins import str
 # pylint:enable=redefined-builtin
 
+import time
+
 from aloe import step, world
 
 from aloe_webdriver.util import (
@@ -362,13 +364,10 @@ TEXT_FIELDS = (
 )
 
 
-@step('I fill in "([^"]*)" with "([^"]*)"$')
-@step("I fill in '([^']*)' with '([^']*)'$")
-@wait_for
-def fill_in_textfield(self, field_name, value):
+def fill_in_textfield_with_delay_ms(self, field_name, value, delay_ms):
     """
     Fill in the HTML input with given label (recommended), name or id with
-    the given text.
+    the given text, delaying 'delay_ms' between keys.
 
     Supported input types are text, textarea, password, month, time, week,
     number, range, email, url, tel and color.
@@ -392,7 +391,42 @@ def fill_in_textfield(self, field_name, value):
     else:
         field.clear()
 
-    field.send_keys(value)
+    if delay_ms == 0:
+        field.send_keys(value)
+    else:
+        for char in value:
+            field.send_keys(char)
+            time.sleep(delay_ms / 1000.0)
+
+
+@step('I fill in "([^"]*)" with "([^"]*)"$')
+@step("I fill in '([^']*)' with '([^']*)'$")
+@wait_for
+def fill_in_textfield_no_delay(self, field_name, value):
+    """
+    Fill in the HTML input with given label (recommended), name or id with
+    the given text.
+
+    Supported input types are text, textarea, password, month, time, week,
+    number, range, email, url, tel and color.
+    """
+
+    fill_in_textfield_with_delay_ms(self, field_name, value, 0)
+
+
+@step('I slowly fill in "([^"]*)" with "([^"]*)"$')
+@step("I slowly fill in '([^']*)' with '([^']*)'$")
+@wait_for
+def fill_in_textfield_slowly(self, field_name, value):
+    """
+    Fill in the HTML input with given label (recommended), name or id with
+    the given text, waiting a small amount of time (1ms) between each key.
+
+    Supported input types are text, textarea, password, month, time, week,
+    number, range, email, url, tel and color.
+    """
+
+    fill_in_textfield_with_delay_ms(self, field_name, value, 10)
 
 
 @step('I press "([^"]*)"$')

--- a/aloe_webdriver/tests/html_pages/slow_text_field.html
+++ b/aloe_webdriver/tests/html_pages/slow_text_field.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>A text field requiring slow input</title>
+  </head>
+  <body>
+    <input type="text" id="input" onkeypress="copy_key(event)" />
+    <span id="fast">Fast: </span>
+    <span id="slow">Slow: </span>
+    <script>
+      function copy_key(event) {
+          var key = event.which || event.keyCode;
+          var input = document.getElementById("input");
+
+          /* Copy to the slow span each key pressed */
+          var slow = document.getElementById("slow");
+          slow.innerHTML = slow.innerHTML + String.fromCharCode(key);
+
+          /* Copy to the fast span the contents of the input field */
+          var fast = document.getElementById("fast");
+          fast.innerHTML = fast.innerHTML + input.value;
+
+          /* And clear the input field after a 1 ms delay */
+          setTimeout(function() {input.value = "";}, 1);
+      }
+    </script>
+  </body>
+</html>

--- a/aloe_webdriver/tests/test_webdriver.py
+++ b/aloe_webdriver/tests/test_webdriver.py
@@ -79,6 +79,17 @@ class TestSteps(FeatureTest):
         """
 
     @feature()
+    def test_I_slowly_fill_in(self):
+        """
+        When I visit test page "slow_text_field"
+        And I fill in "input" with "input"
+        Then I should see "Fast: iininpinpu Slow: input"
+        When I visit test page "slow_text_field"
+        And I slowly fill in "input" with "input"
+        Then I should see "Fast: Slow: input"
+        """
+
+    @feature()
     def test_checkboxes_checked(self):
         """
         Given I visit test page "basic_page"


### PR DESCRIPTION
With a tiny (1ms) delay between keystrokes.

This is to allow for testing some (poorly-written) websites that fail
when text is entered very quickly.

This commit includes a test for the new functionality, (with some
javascript code that will behave differently depending on if text is
entered quickly or relatively slowly).
