### PR TITLE
Add a retry_on_timeout decorator and use it on the lowest-level visit step

### DIFF
--- a/aloe_webdriver/__init__.py
+++ b/aloe_webdriver/__init__.py
@@ -19,8 +19,9 @@ from aloe_webdriver.util import (
     find_field,
     find_option,
     option_in_select,
-    wait_for,
+    retry_on_timeout,
     string_literal,
+    wait_for,
 )
 
 from nose.tools import (
@@ -72,6 +73,7 @@ def contains_content(browser, content):
 
 @step('I visit "(.*?)"$')
 @step('I go to "(.*?)"$')
+@retry_on_timeout
 def visit(self, url):
     """Navigate to the provided (fully qualified) URL."""
     world.browser.get(url)

--- a/aloe_webdriver/util.py
+++ b/aloe_webdriver/util.py
@@ -11,6 +11,7 @@ from builtins import str
 # pylint:enable=redefined-builtin
 
 import operator
+import sys
 from copy import copy
 from time import time, sleep
 from functools import wraps
@@ -535,8 +536,12 @@ def retry_on_timeout(func):
             except TimeoutException:
                 retries -= 1
                 if retries > 0:
+                    sys.stderr.write("retry_on_timeout: Retrying with "
+                                     "{} retries remaining".format(retries))
                     continue
                 else:
+                    sys.stderr.write("retry_on_timeout: Not retrying anymore"
+                                     "---allowing exception to pass through")
                     raise
 
     return wrapped

--- a/aloe_webdriver/util.py
+++ b/aloe_webdriver/util.py
@@ -13,6 +13,7 @@ from builtins import str
 import operator
 from copy import copy
 from time import time, sleep
+from functools import wraps
 from selenium.common.exceptions import TimeoutException
 
 try:
@@ -486,6 +487,7 @@ def wait_for(func):
     for (default 15).
     """
 
+    @wraps(func)
     def wrapped(*args, **kwargs):
         timeout = kwargs.pop('timeout', TIMEOUT)
 
@@ -523,6 +525,7 @@ def retry_on_timeout(func):
     for (default 5).
     """
 
+    @wraps(func)
     def wrapped(*args, **kwargs):
         retries = kwargs.pop('retries', RETRIES)
 

--- a/aloe_webdriver/util.py
+++ b/aloe_webdriver/util.py
@@ -13,6 +13,7 @@ from builtins import str
 import operator
 from copy import copy
 from time import time, sleep
+from selenium.common.exceptions import TimeoutException
 
 try:
     reduce
@@ -503,6 +504,34 @@ def wait_for(func):
                     start = time()
                 if time() - start < timeout:
                     sleep(CHECK_EVERY)
+                    continue
+                else:
+                    raise
+
+    return wrapped
+
+
+RETRIES = 5
+
+
+def retry_on_timeout(func):
+    """
+    A decorator to invoke a function, retrying on timeout exceptions for a
+    specified number of times.
+
+    Adds a kwarg `retires` to `func` which is the number of times to try
+    for (default 5).
+    """
+
+    def wrapped(*args, **kwargs):
+        retries = kwargs.pop('retries', RETRIES)
+
+        while True:
+            try:
+                return func(*args, **kwargs)
+            except TimeoutException:
+                retries -= 1
+                if retries > 0:
                     continue
                 else:
                     raise

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ if __name__ == '__main__':
             open('README.md') as readme:
         setup(
             name='aloe_webdriver',
-            use_scm_version=True,
+            version="0.5.2+nimbis.retry.on.timeout",
             description='Selenium webdriver extension for Aloe',
             author=", ".join((
                 'Alexey Kotlyarov',


### PR DESCRIPTION
The first commit in this pull request adds the retry_on_timeout decorator needed to deal with TimeoutExceptions generated by code that calls Selenium's set_page_load_timeout, (along with a phantomjs bug where page loads hang forever for some reason).

I've already sent that first commit to upstream in a pull request.

The second commit just adds a little extra print to the log whenever a retry occurs, (so we can watch Travis logs to characterize when the phantomjs bug is acting up).
